### PR TITLE
Add cut / copy / paste / duplicate functions to animation tree editors

### DIFF
--- a/editor/plugins/animation_blend_space_1d_editor.h
+++ b/editor/plugins/animation_blend_space_1d_editor.h
@@ -104,6 +104,7 @@ class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 	bool dragging_selected = false;
 	Vector2 drag_from;
 	Vector2 drag_ofs;
+	bool drag_copy = false;
 
 	void _add_menu_type(int p_index);
 	void _add_animation_type(int p_index);
@@ -119,11 +120,14 @@ class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 	Ref<AnimationNode> file_loaded;
 	void _file_opened(const String &p_file);
 
-	enum {
-		MENU_LOAD_FILE = 1000,
-		MENU_PASTE = 1001,
-		MENU_LOAD_FILE_CONFIRM = 1002
-	};
+	float _map_to_blend_space(float p_mouse);
+
+	Ref<AnimationRootNode> copy_node;
+	Ref<AnimationRootNode> _dup_copy_point();
+	void _dup_paste_point(Ref<AnimationNode> node, float p_position);
+	void _duplicate_point(float p_position);
+	void _copy_point(bool p_cut);
+	void _paste_point(float p_position);
 
 	StringName get_blend_position_path() const;
 
@@ -135,6 +139,7 @@ public:
 	static AnimationNodeBlendSpace1DEditor *get_singleton() { return singleton; }
 	virtual bool can_edit(const Ref<AnimationNode> &p_node) override;
 	virtual void edit(const Ref<AnimationNode> &p_node) override;
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 	AnimationNodeBlendSpace1DEditor();
 };
 

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -64,6 +64,64 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_changed() {
 	blend_space_draw->queue_redraw();
 }
 
+Vector2 AnimationNodeBlendSpace2DEditor::_map_to_blend_space(const Vector2 &p_mouse) {
+	Vector2 mapped = (p_mouse / blend_space_draw->get_size());
+	mapped.y = 1.0 - mapped.y;
+	mapped *= (blend_space->get_max_space() - blend_space->get_min_space());
+	mapped += blend_space->get_min_space();
+	if (snap->is_pressed()) {
+		mapped = mapped.snapped(blend_space->get_snap());
+	}
+	return mapped;
+}
+
+Ref<AnimationRootNode> AnimationNodeBlendSpace2DEditor::_dup_copy_point() {
+	if (selected_point >= 0 && selected_point < blend_space->get_blend_point_count()) {
+		return blend_space->get_blend_point_node(selected_point)->duplicate();
+	}
+	return nullptr;
+}
+
+void AnimationNodeBlendSpace2DEditor::_dup_paste_point(Ref<AnimationNode> node, const Vector2 &p_position) {
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->add_do_method(blend_space.ptr(), "add_blend_point", node->duplicate(), p_position);
+	undo_redo->add_do_method(this, "_update_space");
+	undo_redo->add_undo_method(blend_space.ptr(), "remove_blend_point", blend_space->get_blend_point_count());
+	undo_redo->add_undo_method(this, "_update_space");
+}
+
+void AnimationNodeBlendSpace2DEditor::_duplicate_point(const Vector2 &p_position) {
+	Ref<AnimationRootNode> node = _dup_copy_point();
+	if (node.is_valid()) {
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Duplicate 2D Blend Point"));
+		_dup_paste_point(node, p_position);
+		undo_redo->commit_action();
+	}
+}
+
+void AnimationNodeBlendSpace2DEditor::_copy_point(bool p_cut) {
+	copy_node = _dup_copy_point();
+	if (copy_node.is_valid() && p_cut) {
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Cut 2D Blend Point"));
+		undo_redo->add_do_method(blend_space.ptr(), "remove_blend_point", selected_point);
+		undo_redo->add_do_method(this, "_update_space");
+		undo_redo->add_undo_method(blend_space.ptr(), "add_blend_point", copy_node->duplicate(), blend_space->get_blend_point_position(selected_point));
+		undo_redo->add_undo_method(this, "_update_space");
+		undo_redo->commit_action();
+	}
+}
+
+void AnimationNodeBlendSpace2DEditor::_paste_point(const Vector2 &p_position) {
+	if (copy_node.is_valid()) {
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Paste 2D Blend Point"));
+		_dup_paste_point(copy_node, p_position);
+		undo_redo->commit_action();
+	}
+}
+
 void AnimationNodeBlendSpace2DEditor::edit(const Ref<AnimationNode> &p_node) {
 	if (blend_space.is_valid()) {
 		blend_space->disconnect("triangles_updated", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_blend_space_changed));
@@ -93,6 +151,33 @@ void AnimationNodeBlendSpace2DEditor::edit(const Ref<AnimationNode> &p_node) {
 	interpolation->set_disabled(read_only);
 }
 
+void AnimationNodeBlendSpace2DEditor::shortcut_input(const Ref<InputEvent> &p_event) {
+	if (!is_visible_in_tree()) {
+		return;
+	}
+
+	if (!is_focus_owner_in_shortcut_context()) {
+		return;
+	}
+
+	Ref<InputEventKey> k = p_event;
+	if (k.is_valid() && k->is_pressed() && !k->is_echo()) {
+		if (ED_IS_SHORTCUT("blend_tree_editor/cut", p_event)) {
+			accept_event();
+			_copy_point(true);
+		} else if (ED_IS_SHORTCUT("blend_tree_editor/copy", p_event)) {
+			accept_event();
+			_copy_point(false);
+		} else if (ED_IS_SHORTCUT("blend_tree_editor/paste", p_event)) {
+			accept_event();
+			_paste_point(_map_to_blend_space(blend_space_draw->get_local_mouse_position()));
+		} else if (ED_IS_SHORTCUT("blend_tree_editor/duplicate", p_event)) {
+			accept_event();
+			_duplicate_point(_map_to_blend_space(blend_space_draw->get_local_mouse_position()));
+		}
+	}
+}
+
 StringName AnimationNodeBlendSpace2DEditor::get_blend_position_path() const {
 	StringName path = AnimationTreeEditor::get_singleton()->get_base_path() + "blend_position";
 	return path;
@@ -115,7 +200,6 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 	}
 
 	Ref<InputEventMouseButton> mb = p_event;
-
 	if (mb.is_valid() && mb->is_pressed() && ((tool_select->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) || (mb->get_button_index() == MouseButton::LEFT && tool_create->is_pressed()))) {
 		if (!read_only) {
 			menu->clear(false);
@@ -144,25 +228,15 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 				menu->set_item_metadata(idx, E);
 			}
 
-			Ref<AnimationNode> clipb = EditorSettings::get_singleton()->get_resource_clipboard();
-			if (clipb.is_valid()) {
-				menu->add_separator();
-				menu->add_item(TTR("Paste"), MENU_PASTE);
-			}
+			_add_standard_context_menu_items(menu, selected_point >= 0, copy_node.is_valid());
+			add_point_pos = _map_to_blend_space(mb->get_position());
+
 			menu->add_separator();
 			menu->add_item(TTR("Load..."), MENU_LOAD_FILE);
 
 			menu->set_position(blend_space_draw->get_screen_position() + mb->get_position());
 			menu->reset_size();
 			menu->popup();
-			add_point_pos = (mb->get_position() / blend_space_draw->get_size());
-			add_point_pos.y = 1.0 - add_point_pos.y;
-			add_point_pos *= (blend_space->get_max_space() - blend_space->get_min_space());
-			add_point_pos += blend_space->get_min_space();
-
-			if (snap->is_pressed()) {
-				add_point_pos = add_point_pos.snapped(blend_space->get_snap());
-			}
 		}
 	}
 
@@ -180,6 +254,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 				EditorNode::get_singleton()->push_item(node.ptr(), "", true);
 				dragging_selected_attempt = true;
 				drag_from = mb->get_position();
+				drag_copy = mb->is_command_or_control_pressed();
 				_update_tool_erase();
 				_update_edited_point_pos();
 				return;
@@ -252,18 +327,22 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 			}
 
 			if (!read_only) {
-				updating = true;
-				EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-				undo_redo->create_action(TTR("Move Node Point"));
-				undo_redo->add_do_method(blend_space.ptr(), "set_blend_point_position", selected_point, point);
-				undo_redo->add_undo_method(blend_space.ptr(), "set_blend_point_position", selected_point, blend_space->get_blend_point_position(selected_point));
-				undo_redo->add_do_method(this, "_update_space");
-				undo_redo->add_undo_method(this, "_update_space");
-				undo_redo->add_do_method(this, "_update_edited_point_pos");
-				undo_redo->add_undo_method(this, "_update_edited_point_pos");
-				undo_redo->commit_action();
-				updating = false;
-				_update_edited_point_pos();
+				if (!drag_copy) {
+					updating = true;
+					EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+					undo_redo->create_action(TTR("Move Node Point"));
+					undo_redo->add_do_method(blend_space.ptr(), "set_blend_point_position", selected_point, point);
+					undo_redo->add_undo_method(blend_space.ptr(), "set_blend_point_position", selected_point, blend_space->get_blend_point_position(selected_point));
+					undo_redo->add_do_method(this, "_update_space");
+					undo_redo->add_undo_method(this, "_update_space");
+					undo_redo->add_do_method(this, "_update_edited_point_pos");
+					undo_redo->add_undo_method(this, "_update_edited_point_pos");
+					undo_redo->commit_action();
+					updating = false;
+					_update_edited_point_pos();
+				} else {
+					_duplicate_point(point);
+				}
 			}
 		}
 		dragging_selected_attempt = false;
@@ -342,8 +421,21 @@ void AnimationNodeBlendSpace2DEditor::_add_menu_type(int p_index) {
 	} else if (p_index == MENU_LOAD_FILE_CONFIRM) {
 		node = file_loaded;
 		file_loaded.unref();
+	} else if (p_index == MENU_CUT) {
+		_copy_point(true);
+		return;
+	} else if (p_index == MENU_COPY) {
+		_copy_point(false);
+		return;
 	} else if (p_index == MENU_PASTE) {
-		node = EditorSettings::get_singleton()->get_resource_clipboard();
+		_paste_point(add_point_pos);
+		return;
+	} else if (p_index == MENU_DUPLICATE) {
+		_duplicate_point(add_point_pos);
+		return;
+	} else if (p_index == MENU_DELETE) {
+		_erase_selected();
+		return;
 	} else {
 		String type = menu->get_item_metadata(p_index);
 

--- a/editor/plugins/animation_blend_space_2d_editor.h
+++ b/editor/plugins/animation_blend_space_2d_editor.h
@@ -109,6 +109,7 @@ class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 	bool dragging_selected;
 	Vector2 drag_from;
 	Vector2 drag_ofs;
+	bool drag_copy = false;
 
 	Vector<int> making_triangle;
 
@@ -130,13 +131,16 @@ class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 	Ref<AnimationNode> file_loaded;
 	void _file_opened(const String &p_file);
 
-	enum {
-		MENU_LOAD_FILE = 1000,
-		MENU_PASTE = 1001,
-		MENU_LOAD_FILE_CONFIRM = 1002
-	};
-
 	void _blend_space_changed();
+
+	Vector2 _map_to_blend_space(const Vector2 &p_mouse);
+
+	Ref<AnimationRootNode> copy_node;
+	Ref<AnimationRootNode> _dup_copy_point();
+	void _dup_paste_point(Ref<AnimationNode> node, const Vector2 &p_position);
+	void _duplicate_point(const Vector2 &p_position);
+	void _copy_point(bool p_cut);
+	void _paste_point(const Vector2 &p_position);
 
 protected:
 	void _notification(int p_what);
@@ -146,6 +150,7 @@ public:
 	static AnimationNodeBlendSpace2DEditor *get_singleton() { return singleton; }
 	virtual bool can_edit(const Ref<AnimationNode> &p_node) override;
 	virtual void edit(const Ref<AnimationNode> &p_node) override;
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 	AnimationNodeBlendSpace2DEditor();
 };
 

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -76,8 +76,11 @@ void AnimationNodeBlendTreeEditor::remove_custom_type(const Ref<Script> &p_scrip
 }
 
 void AnimationNodeBlendTreeEditor::_update_options_menu(bool p_has_input_ports) {
+	popup_menu_point = graph->get_local_mouse_position();
+
 	add_node->get_popup()->clear();
 	add_node->get_popup()->reset_size();
+
 	for (int i = 0; i < add_options.size(); i++) {
 		if (p_has_input_ports && add_options[i].input_port_count == 0) {
 			continue;
@@ -85,13 +88,22 @@ void AnimationNodeBlendTreeEditor::_update_options_menu(bool p_has_input_ports) 
 		add_node->get_popup()->add_item(add_options[i].name, i);
 	}
 
-	Ref<AnimationNode> clipb = EditorSettings::get_singleton()->get_resource_clipboard();
-	if (clipb.is_valid()) {
-		add_node->get_popup()->add_separator();
-		add_node->get_popup()->add_item(TTR("Paste"), MENU_PASTE);
+	bool can_copy = false;
+	for (int i = 0; i < graph->get_child_count(false); ++i) {
+		GraphNode *graph_node = Object::cast_to<GraphNode>(graph->get_child(i, false));
+		if (graph_node && graph_node->is_selected()) {
+			can_copy = true;
+			break;
+		}
 	}
+
+	bool can_paste = !copy_items_buffer.is_empty();
+
+	_add_standard_context_menu_items(add_node->get_popup(), can_copy, can_paste);
+
 	add_node->get_popup()->add_separator();
 	add_node->get_popup()->add_item(TTR("Load..."), MENU_LOAD_FILE);
+
 	use_position_from_popup_menu = false;
 }
 
@@ -297,6 +309,179 @@ void AnimationNodeBlendTreeEditor::_file_opened(const String &p_file) {
 	}
 }
 
+void AnimationNodeBlendTreeEditor::_dup_copy_nodes(List<CopyItem> &r_items, List<GraphEdit::Connection> &r_connections) {
+	Vector2 top_left = {
+		std::numeric_limits<real_t>::max(),
+		std::numeric_limits<real_t>::max()
+	};
+
+	for (int i = 0; i < graph->get_child_count(); i++) {
+		GraphElement *graph_element = Object::cast_to<GraphElement>(graph->get_child(i));
+		if (!graph_element) {
+			continue;
+		}
+
+		if (!graph_element->is_selected()) {
+			continue;
+		}
+
+		Vector2 position = blend_tree->get_node_position(graph_element->get_name());
+		if (position.x < top_left.x) {
+			top_left.x = position.x;
+		}
+		if (position.y < top_left.y) {
+			top_left.y = position.y;
+		}
+	}
+
+	HashSet<StringName> nodes;
+
+	for (int i = 0; i < graph->get_child_count(); i++) {
+		GraphElement *graph_element = Object::cast_to<GraphElement>(graph->get_child(i));
+		if (!graph_element) {
+			continue;
+		}
+
+		if (!graph_element->is_selected()) {
+			continue;
+		}
+
+		Ref<AnimationNode> node = blend_tree->get_node(graph_element->get_name());
+		if (!node.is_valid()) {
+			continue;
+		}
+
+		Ref<AnimationNodeOutput> output(node);
+		if (output.is_valid()) { // can't duplicate output
+			continue;
+		}
+
+		Vector2 position = blend_tree->get_node_position(graph_element->get_name());
+
+		CopyItem item;
+		item.name = graph_element->get_name();
+		item.node = node->duplicate();
+		item.position = position - top_left;
+
+		r_items.push_back(item);
+
+		nodes.insert(graph_element->get_name());
+	}
+
+	List<GraphEdit::Connection> node_connections;
+	//blend_tree->get_node_connections(&node_connections);
+	graph->get_connection_list(&node_connections);
+
+	for (const GraphEdit::Connection &E : node_connections) {
+		if (nodes.has(E.from_node) && nodes.has(E.to_node)) {
+			r_connections.push_back(E);
+		}
+	}
+}
+
+void AnimationNodeBlendTreeEditor::_dup_paste_nodes(List<CopyItem> &p_items, const List<GraphEdit::Connection> &p_connections, const Vector2 &p_position, bool p_duplicate) {
+	if (p_items.is_empty()) {
+		return;
+	}
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	if (p_duplicate) {
+		undo_redo->create_action(TTR("Duplicate AnimationTree Node(s)"));
+	} else {
+		undo_redo->create_action(TTR("Paste AnimationTree Node(s)"));
+	}
+
+	HashMap<StringName, StringName> connection_remap;
+	HashSet<StringName> added_set;
+
+	float scale = graph->get_zoom();
+	Vector2 position = graph->get_scroll_offset() / scale + p_position / scale;
+
+	for (CopyItem &item : p_items) {
+		String name = _deduplicate_node_name(item.name);
+		connection_remap[item.name] = name;
+		// must duplicate node again for multiple pastes
+		undo_redo->add_do_method(blend_tree.ptr(), "add_node", name, item.node->duplicate(), item.position + position);
+		added_set.insert(name);
+	}
+
+	for (const GraphEdit::Connection &E : p_connections) {
+		undo_redo->add_do_method(blend_tree.ptr(), "connect_node", String(connection_remap[E.to_node]), E.to_port, String(connection_remap[E.from_node]));
+		undo_redo->add_undo_method(blend_tree.ptr(), "disconnect_node", connection_remap[E.to_node], E.to_port);
+	}
+
+	for (const CopyItem &item : p_items) {
+		undo_redo->add_undo_method(blend_tree.ptr(), "remove_node", connection_remap[item.name]);
+	}
+
+	undo_redo->add_do_method(this, "update_graph");
+	undo_redo->add_undo_method(this, "update_graph");
+
+	undo_redo->commit_action();
+
+	// select the new nodes so that the user can easily move them away
+	for (int i = 0; i < graph->get_child_count(); i++) {
+		GraphElement *graph_element = Object::cast_to<GraphElement>(graph->get_child(i));
+		if (graph_element) {
+			graph_element->set_selected(added_set.has(graph_element->get_name()));
+		}
+	}
+}
+
+void AnimationNodeBlendTreeEditor::_duplicate_nodes(const Vector2 &p_position) {
+	List<CopyItem> items;
+	List<GraphEdit::Connection> node_connections;
+	_dup_copy_nodes(items, node_connections);
+
+	if (items.is_empty()) {
+		return;
+	}
+
+	_dup_paste_nodes(items, node_connections, p_position, true);
+}
+
+void AnimationNodeBlendTreeEditor::_clear_copy_buffer() {
+	copy_items_buffer.clear();
+	copy_connections_buffer.clear();
+}
+
+void AnimationNodeBlendTreeEditor::_copy_nodes(bool p_cut) {
+	_clear_copy_buffer();
+
+	_dup_copy_nodes(copy_items_buffer, copy_connections_buffer);
+
+	if (p_cut) {
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Cut BlendTree Node(s)"));
+
+		TypedArray<StringName> names;
+		for (const CopyItem &E : copy_items_buffer) {
+			names.push_back(E.name);
+		}
+
+		_delete_nodes_request(names);
+		//update_graph();
+
+		undo_redo->commit_action();
+	}
+}
+
+void AnimationNodeBlendTreeEditor::_paste_nodes(const Vector2 &p_position) {
+	if (!copy_items_buffer.is_empty()) {
+		_dup_paste_nodes(copy_items_buffer, copy_connections_buffer, p_position, false);
+	}
+}
+
+String AnimationNodeBlendTreeEditor::_deduplicate_node_name(const String &p_name) {
+	int base = 1;
+	String name = p_name;
+	while (blend_tree->has_node(name)) {
+		base++;
+		name = p_name + " " + itos(base);
+	}
+	return name;
+}
+
 void AnimationNodeBlendTreeEditor::_add_node(int p_idx) {
 	Ref<AnimationNode> anode;
 
@@ -315,10 +500,22 @@ void AnimationNodeBlendTreeEditor::_add_node(int p_idx) {
 		anode = file_loaded;
 		file_loaded.unref();
 		base_name = anode->get_class();
+	} else if (p_idx == MENU_DUPLICATE) {
+		_duplicate_nodes(popup_menu_point);
+		return;
+	} else if (p_idx == MENU_CUT) {
+		_copy_nodes(true);
+		return;
+	} else if (p_idx == MENU_COPY) {
+		_copy_nodes(false);
+		return;
 	} else if (p_idx == MENU_PASTE) {
-		anode = EditorSettings::get_singleton()->get_resource_clipboard();
-		ERR_FAIL_COND(!anode.is_valid());
-		base_name = anode->get_class();
+		_paste_nodes(popup_menu_point);
+		return;
+	} else if (p_idx == MENU_DELETE) {
+		_delete_nodes_request({});
+		update_graph();
+		return;
 	} else if (!add_options[p_idx].type.is_empty()) {
 		AnimationNode *an = Object::cast_to<AnimationNode>(ClassDB::instantiate(add_options[p_idx].type));
 		ERR_FAIL_NULL(an);
@@ -428,16 +625,33 @@ void AnimationNodeBlendTreeEditor::_popup_hide() {
 	to_slot = -1;
 }
 
+void AnimationNodeBlendTreeEditor::_begin_node_move() {
+	if (Input::get_singleton()->is_key_pressed(Key::CMD_OR_CTRL)) {
+		drag_copy = true;
+	}
+}
+
+void AnimationNodeBlendTreeEditor::_end_node_move() {
+	set_process_shortcut_input(true);
+	set_shortcut_context(this);
+	if (drag_copy) {
+		_duplicate_nodes(graph->get_local_mouse_position());
+		drag_copy = false;
+	}
+}
+
 void AnimationNodeBlendTreeEditor::_node_dragged(const Vector2 &p_from, const Vector2 &p_to, const StringName &p_which) {
-	updating = true;
-	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(TTR("Node Moved"));
-	undo_redo->add_do_method(blend_tree.ptr(), "set_node_position", p_which, p_to / EDSCALE);
-	undo_redo->add_undo_method(blend_tree.ptr(), "set_node_position", p_which, p_from / EDSCALE);
-	undo_redo->add_do_method(this, "update_graph");
-	undo_redo->add_undo_method(this, "update_graph");
-	undo_redo->commit_action();
-	updating = false;
+	if (!drag_copy) {
+		updating = true;
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Node Moved"));
+		undo_redo->add_do_method(blend_tree.ptr(), "set_node_position", p_which, p_to / EDSCALE);
+		undo_redo->add_undo_method(blend_tree.ptr(), "set_node_position", p_which, p_from / EDSCALE);
+		undo_redo->add_do_method(this, "update_graph");
+		undo_redo->add_undo_method(this, "update_graph");
+		undo_redo->commit_action();
+		updating = false;
+	}
 }
 
 void AnimationNodeBlendTreeEditor::_connection_request(const String &p_from, int p_from_index, const String &p_to, int p_to_index) {
@@ -951,13 +1165,7 @@ void AnimationNodeBlendTreeEditor::_node_renamed(const String &p_text, Ref<Anima
 		return; //nothing to do
 	}
 
-	const String &base_name = new_name;
-	int base = 1;
-	String name = base_name;
-	while (blend_tree->has_node(name)) {
-		base++;
-		name = base_name + " " + itos(base);
-	}
+	String name = _deduplicate_node_name(new_name);
 
 	String base_path = AnimationTreeEditor::get_singleton()->get_base_path();
 
@@ -1048,6 +1256,33 @@ void AnimationNodeBlendTreeEditor::edit(const Ref<AnimationNode> &p_node) {
 	graph->set_show_arrange_button(!read_only);
 }
 
+void AnimationNodeBlendTreeEditor::shortcut_input(const Ref<InputEvent> &p_event) {
+	if (!is_visible_in_tree()) {
+		return;
+	}
+
+	if (!is_focus_owner_in_shortcut_context()) {
+		return;
+	}
+
+	Ref<InputEventKey> k = p_event;
+	if (k.is_valid() && !k->is_echo()) {
+		if (ED_IS_SHORTCUT("blend_tree_editor/cut", p_event)) {
+			accept_event();
+			_copy_nodes(true);
+		} else if (ED_IS_SHORTCUT("blend_tree_editor/copy", p_event)) {
+			accept_event();
+			_copy_nodes(false);
+		} else if (ED_IS_SHORTCUT("blend_tree_editor/paste", p_event)) {
+			accept_event();
+			_paste_nodes(graph->get_local_mouse_position());
+		} else if (ED_IS_SHORTCUT("blend_tree_editor/duplicate", p_event)) {
+			accept_event();
+			_duplicate_nodes(graph->get_local_mouse_position());
+		}
+	}
+}
+
 AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 	singleton = this;
 	updating = false;
@@ -1066,6 +1301,8 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 	graph->connect("popup_request", callable_mp(this, &AnimationNodeBlendTreeEditor::_popup_request));
 	graph->connect("connection_to_empty", callable_mp(this, &AnimationNodeBlendTreeEditor::_connection_to_empty));
 	graph->connect("connection_from_empty", callable_mp(this, &AnimationNodeBlendTreeEditor::_connection_from_empty));
+	graph->connect("begin_node_move", callable_mp(this, &AnimationNodeBlendTreeEditor::_begin_node_move));
+	graph->connect("end_node_move", callable_mp(this, &AnimationNodeBlendTreeEditor::_end_node_move));
 	float graph_minimap_opacity = EDITOR_GET("editors/visual_editors/minimap_opacity");
 	graph->set_minimap_opacity(graph_minimap_opacity);
 	float graph_lines_curvature = EDITOR_GET("editors/visual_editors/lines_curvature");
@@ -1098,7 +1335,6 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 	add_options.push_back(AddOption("BlendSpace1D", "AnimationNodeBlendSpace1D"));
 	add_options.push_back(AddOption("BlendSpace2D", "AnimationNodeBlendSpace2D"));
 	add_options.push_back(AddOption("StateMachine", "AnimationNodeStateMachine"));
-	_update_options_menu();
 
 	error_panel = memnew(PanelContainer);
 	add_child(error_panel);

--- a/editor/plugins/animation_blend_tree_editor_plugin.h
+++ b/editor/plugins/animation_blend_tree_editor_plugin.h
@@ -98,6 +98,8 @@ class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	void _node_renamed_focus_out(Ref<AnimationNode> p_node);
 	void _node_rename_lineedit_changed(const String &p_text);
 	void _node_changed(const StringName &p_node_name);
+	void _begin_node_move();
+	void _end_node_move();
 
 	String current_node_rename_text;
 	bool updating;
@@ -132,11 +134,26 @@ class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	Ref<AnimationNode> file_loaded;
 	void _file_opened(const String &p_file);
 
-	enum {
-		MENU_LOAD_FILE = 1000,
-		MENU_PASTE = 1001,
-		MENU_LOAD_FILE_CONFIRM = 1002
+	Vector2 popup_menu_point;
+
+	struct CopyItem {
+		StringName name;
+		Ref<AnimationNode> node;
+		Vector2 position;
 	};
+
+	List<CopyItem> copy_items_buffer;
+	List<GraphEdit::Connection> copy_connections_buffer;
+	bool drag_copy = false;
+
+	void _dup_copy_nodes(List<CopyItem> &r_items, List<GraphEdit::Connection> &r_connections);
+	void _dup_paste_nodes(List<CopyItem> &p_items, const List<GraphEdit::Connection> &p_connections, const Vector2 &p_position, bool p_duplicate);
+	void _duplicate_nodes(const Vector2 &p_position);
+	void _copy_nodes(bool p_cut);
+	void _paste_nodes(const Vector2 &p_position);
+	void _clear_copy_buffer();
+
+	String _deduplicate_node_name(const String &p_name);
 
 protected:
 	void _notification(int p_what);
@@ -152,6 +169,8 @@ public:
 
 	virtual bool can_edit(const Ref<AnimationNode> &p_node) override;
 	virtual void edit(const Ref<AnimationNode> &p_node) override;
+
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
 	void update_graph();
 

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -158,7 +158,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 	}
 
 	// Select node or push a field inside
-	if (mb.is_valid() && !mb->is_shift_pressed() && !mb->is_command_or_control_pressed() && mb->is_pressed() && tool_select->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
+	if (mb.is_valid() && !mb->is_shift_pressed() && mb->is_pressed() && tool_select->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
 		selected_transition_from = StringName();
 		selected_transition_to = StringName();
 		selected_transition_index = -1;
@@ -217,6 +217,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 				dragging_selected_attempt = true;
 				dragging_selected = false;
 				drag_from = mb->get_position();
+				drag_copy = mb->is_command_or_control_pressed();
 				snap_x = StringName();
 				snap_y = StringName();
 				_update_mode();
@@ -266,24 +267,28 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 	if (mb.is_valid() && dragging_selected_attempt && mb->get_button_index() == MouseButton::LEFT && !mb->is_pressed()) {
 		if (dragging_selected) {
 			Ref<AnimationNode> an = state_machine->get_node(selected_node);
-			updating = true;
+			if (!drag_copy) {
+				updating = true;
 
-			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-			undo_redo->create_action(TTR("Move Node"));
+				EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+				undo_redo->create_action(TTR("Move Node"));
 
-			for (int i = 0; i < node_rects.size(); i++) {
-				if (!selected_nodes.has(node_rects[i].node_name)) {
-					continue;
+				for (int i = 0; i < node_rects.size(); i++) {
+					if (!selected_nodes.has(node_rects[i].node_name)) {
+						continue;
+					}
+
+					undo_redo->add_do_method(state_machine.ptr(), "set_node_position", node_rects[i].node_name, state_machine->get_node_position(node_rects[i].node_name) + drag_ofs / EDSCALE);
+					undo_redo->add_undo_method(state_machine.ptr(), "set_node_position", node_rects[i].node_name, state_machine->get_node_position(node_rects[i].node_name));
 				}
 
-				undo_redo->add_do_method(state_machine.ptr(), "set_node_position", node_rects[i].node_name, state_machine->get_node_position(node_rects[i].node_name) + drag_ofs / EDSCALE);
-				undo_redo->add_undo_method(state_machine.ptr(), "set_node_position", node_rects[i].node_name, state_machine->get_node_position(node_rects[i].node_name));
+				undo_redo->add_do_method(this, "_update_graph");
+				undo_redo->add_undo_method(this, "_update_graph");
+				undo_redo->commit_action();
+				updating = false;
+			} else {
+				_duplicate_nodes();
 			}
-
-			undo_redo->add_do_method(this, "_update_graph");
-			undo_redo->add_undo_method(this, "_update_graph");
-			undo_redo->commit_action();
-			updating = false;
 		}
 		snap_x = StringName();
 		snap_y = StringName();
@@ -329,7 +334,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 	}
 
 	// Start box selecting
-	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT && tool_select->is_pressed()) {
+	if (selected_node == StringName() && mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT && tool_select->is_pressed()) {
 		box_selecting = true;
 		box_selecting_from = box_selecting_to = state_machine_draw->get_local_mouse_position();
 		box_selecting_rect = Rect2(MIN(box_selecting_from.x, box_selecting_to.x),
@@ -551,6 +556,37 @@ String AnimationNodeStateMachineEditor::get_tooltip(const Point2 &p_pos) const {
 	return tooltip_text;
 }
 
+void AnimationNodeStateMachineEditor::shortcut_input(const Ref<InputEvent> &p_event) {
+	if (!is_visible_in_tree()) {
+		return;
+	}
+
+	if (!is_focus_owner_in_shortcut_context()) {
+		return;
+	}
+
+	Ref<InputEventKey> k = p_event;
+	if (k.is_valid() && k->is_pressed() && !k->is_echo()) {
+		if (ED_IS_SHORTCUT("blend_tree_editor/cut", p_event)) {
+			accept_event();
+			_copy_nodes(true);
+		} else if (ED_IS_SHORTCUT("blend_tree_editor/copy", p_event)) {
+			accept_event();
+			_copy_nodes(false);
+		} else if (ED_IS_SHORTCUT("blend_tree_editor/paste", p_event)) {
+			accept_event();
+			_paste_nodes(_map_to_state_machine(state_machine_draw->get_local_mouse_position()));
+		} else if (ED_IS_SHORTCUT("blend_tree_editor/duplicate", p_event)) {
+			accept_event();
+			_duplicate_nodes();
+		}
+	}
+}
+
+Vector2 AnimationNodeStateMachineEditor::_map_to_state_machine(const Vector2 &p_position) {
+	return p_position / EDSCALE + state_machine->get_graph_offset();
+}
+
 void AnimationNodeStateMachineEditor::_open_menu(const Vector2 &p_position) {
 	AnimationTree *tree = AnimationTreeEditor::get_singleton()->get_animation_tree();
 	if (!tree) {
@@ -586,18 +622,20 @@ void AnimationNodeStateMachineEditor::_open_menu(const Vector2 &p_position) {
 		menu->add_item(vformat(TTR("Add %s"), name), idx);
 		menu->set_item_metadata(idx, E->get());
 	}
-	Ref<AnimationNode> clipb = EditorSettings::get_singleton()->get_resource_clipboard();
 
-	if (clipb.is_valid()) {
-		menu->add_separator();
-		menu->add_item(TTR("Paste"), MENU_PASTE);
-	}
+	bool can_copy = !selected_nodes.is_empty();
+	bool can_paste = !copy_items_buffer.is_empty();
+
+	_add_standard_context_menu_items(menu, can_copy, can_paste);
+
 	menu->add_separator();
 	menu->add_item(TTR("Load..."), MENU_LOAD_FILE);
 
 	menu->set_position(state_machine_draw->get_screen_transform().xform(p_position));
+	menu->reset_size();
 	menu->popup();
-	add_node_pos = p_position / EDSCALE + state_machine->get_graph_offset();
+
+	add_node_pos = _map_to_state_machine(p_position);
 }
 
 bool AnimationNodeStateMachineEditor::_create_submenu(PopupMenu *p_menu, Ref<AnimationNodeStateMachine> p_nodesm, const StringName &p_name, const StringName &p_path) {
@@ -701,6 +739,133 @@ void AnimationNodeStateMachineEditor::_file_opened(const String &p_file) {
 	}
 }
 
+void AnimationNodeStateMachineEditor::_dup_copy_nodes(List<CopyItem> &r_items, List<CopyTransition> &r_transitions) {
+	Vector2 top_left = {
+		std::numeric_limits<real_t>::max(),
+		std::numeric_limits<real_t>::max()
+	};
+
+	for (const StringName &node_name : selected_nodes) {
+		if (node_name == "Start" || node_name == "End") {
+			continue;
+		}
+
+		Vector2 position = state_machine->get_node_position(node_name);
+		if (position.x < top_left.x) {
+			top_left.x = position.x;
+		}
+		if (position.y < top_left.y) {
+			top_left.y = position.y;
+		}
+	}
+
+	for (const StringName &node_name : selected_nodes) {
+		if (node_name == "Start" || node_name == "End") {
+			continue;
+		}
+
+		Vector2 position = state_machine->get_node_position(node_name);
+		r_items.push_back({
+				node_name,
+				position - top_left,
+				state_machine->get_node(node_name)->duplicate(),
+		});
+
+		Vector<int> transitions = state_machine->find_transition_from(node_name);
+		for (int index : transitions) {
+			StringName to = state_machine->get_transition_to(index);
+			if (selected_nodes.has(to)) {
+				Ref<AnimationNodeStateMachineTransition> transition = state_machine->get_transition(index)->duplicate();
+				r_transitions.push_back({ node_name, to, transition });
+			}
+		}
+	}
+}
+
+void AnimationNodeStateMachineEditor::_dup_paste_nodes(const List<CopyItem> &p_items, const List<CopyTransition> &p_transitions, const Vector2 &p_position) {
+	updating = true;
+
+	HashMap<StringName, StringName> remap;
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+
+	for (const CopyItem &item : p_items) {
+		String name = _deduplicate_node_name(item.name);
+		remap[item.name] = name;
+		// must duplicate node again for multiple pastes
+		undo_redo->add_do_method(state_machine.ptr(), "add_node", name, item.node->duplicate(), p_position + item.position);
+		undo_redo->add_undo_method(state_machine.ptr(), "remove_node", name);
+	}
+
+	for (const CopyTransition &item : p_transitions) {
+		StringName from = remap[item.from];
+		StringName to = remap[item.to];
+		// must duplicate node again for multiple pastes
+		undo_redo->add_do_method(state_machine.ptr(), "add_transition", from, to, item.transition->duplicate());
+		undo_redo->add_do_method(this, "_update_graph");
+		undo_redo->add_undo_method(state_machine.ptr(), "remove_transition", from, to);
+		undo_redo->add_undo_method(this, "_update_graph");
+	}
+
+	updating = false;
+
+	state_machine_draw->queue_redraw();
+}
+
+void AnimationNodeStateMachineEditor::_duplicate_nodes() {
+	// don't destroy copy state, use separate buffer
+	List<CopyItem> items;
+	List<CopyTransition> transitions;
+	_dup_copy_nodes(items, transitions);
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(TTR("Duplicate State Machine Node(s) and Transition(s)"));
+
+	_dup_paste_nodes(items, transitions, _map_to_state_machine(state_machine_draw->get_local_mouse_position()));
+
+	undo_redo->commit_action();
+}
+
+void AnimationNodeStateMachineEditor::_copy_nodes(bool p_cut) {
+	_clear_copy_buffer();
+	_dup_copy_nodes(copy_items_buffer, copy_transitions_buffer);
+
+	if (p_cut) {
+		TypedArray<StringName> names;
+		for (const CopyItem &E : copy_items_buffer) {
+			names.push_back(E.name);
+		}
+
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Cut State Machine Node(s)"));
+
+		_erase_selected(true);
+
+		undo_redo->commit_action();
+	}
+}
+
+void AnimationNodeStateMachineEditor::_paste_nodes(const Vector2 &p_position) {
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(TTR("Paste State Machine Node(s) and Transition(s)"));
+	_dup_paste_nodes(copy_items_buffer, copy_transitions_buffer, p_position);
+	undo_redo->commit_action();
+}
+
+void AnimationNodeStateMachineEditor::_clear_copy_buffer() {
+	copy_items_buffer.clear();
+	copy_transitions_buffer.clear();
+}
+
+String AnimationNodeStateMachineEditor::_deduplicate_node_name(const String &p_base_name) {
+	int base = 1;
+	String name = p_base_name;
+	while (state_machine->has_node(name)) {
+		base++;
+		name = p_base_name + " " + itos(base);
+	}
+	return name;
+}
+
 void AnimationNodeStateMachineEditor::_add_menu_type(int p_index) {
 	String base_name;
 	Ref<AnimationRootNode> node;
@@ -717,9 +882,23 @@ void AnimationNodeStateMachineEditor::_add_menu_type(int p_index) {
 	} else if (p_index == MENU_LOAD_FILE_CONFIRM) {
 		node = file_loaded;
 		file_loaded.unref();
+	} else if (p_index == MENU_CUT) {
+		_copy_nodes(true);
+		return;
+	} else if (p_index == MENU_COPY) {
+		_copy_nodes(false);
+		return;
 	} else if (p_index == MENU_PASTE) {
-		node = EditorSettings::get_singleton()->get_resource_clipboard();
-
+		_paste_nodes(add_node_pos);
+		return;
+	} else if (p_index == MENU_DELETE) {
+		if (!read_only) {
+			_erase_selected(false);
+		}
+		return;
+	} else if (p_index == MENU_DUPLICATE) {
+		_duplicate_nodes();
+		return;
 	} else {
 		String type = menu->get_item_metadata(p_index);
 
@@ -741,24 +920,7 @@ void AnimationNodeStateMachineEditor::_add_menu_type(int p_index) {
 		base_name = node->get_class().replace_first("AnimationNode", "");
 	}
 
-	int base = 1;
-	String name = base_name;
-	while (state_machine->has_node(name)) {
-		base++;
-		name = base_name + " " + itos(base);
-	}
-
-	updating = true;
-	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(TTR("Add Node and Transition"));
-	undo_redo->add_do_method(state_machine.ptr(), "add_node", name, node, add_node_pos);
-	undo_redo->add_undo_method(state_machine.ptr(), "remove_node", name);
-	connecting_to_node = name;
-	_add_transition(true);
-	undo_redo->commit_action();
-	updating = false;
-
-	state_machine_draw->queue_redraw();
+	_add_node_and_transition(base_name, node);
 }
 
 void AnimationNodeStateMachineEditor::_add_animation_type(int p_index) {
@@ -767,18 +929,16 @@ void AnimationNodeStateMachineEditor::_add_animation_type(int p_index) {
 
 	anim->set_animation(animations_to_add[p_index]);
 
-	String base_name = animations_to_add[p_index].validate_node_name();
-	int base = 1;
-	String name = base_name;
-	while (state_machine->has_node(name)) {
-		base++;
-		name = base_name + " " + itos(base);
-	}
+	_add_node_and_transition(animations_to_add[p_index].validate_node_name(), anim);
+}
+
+void AnimationNodeStateMachineEditor::_add_node_and_transition(const String &p_base_name, Ref<AnimationNode> node) {
+	String name = _deduplicate_node_name(p_base_name);
 
 	updating = true;
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Add Node and Transition"));
-	undo_redo->add_do_method(state_machine.ptr(), "add_node", name, anim, add_node_pos);
+	undo_redo->add_do_method(state_machine.ptr(), "add_node", name, node, add_node_pos);
 	undo_redo->add_undo_method(state_machine.ptr(), "remove_node", name);
 	connecting_to_node = name;
 	_add_transition(true);

--- a/editor/plugins/animation_state_machine_editor.h
+++ b/editor/plugins/animation_state_machine_editor.h
@@ -162,6 +162,7 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	bool dragging_selected = false;
 	Vector2 drag_from;
 	Vector2 drag_ofs;
+	bool drag_copy = false;
 	StringName snap_x;
 	StringName snap_y;
 
@@ -173,6 +174,7 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 
 	void _add_menu_type(int p_index);
 	void _add_animation_type(int p_index);
+	void _add_node_and_transition(const String &p_base_name, Ref<AnimationNode> node);
 	void _connect_to(int p_index);
 
 	struct NodeRect {
@@ -281,11 +283,31 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	Ref<AnimationNode> file_loaded;
 	void _file_opened(const String &p_file);
 
-	enum {
-		MENU_LOAD_FILE = 1000,
-		MENU_PASTE = 1001,
-		MENU_LOAD_FILE_CONFIRM = 1002
+	Vector2 popup_menu_point;
+
+	struct CopyItem {
+		StringName name;
+		Vector2 position;
+		Ref<AnimationNode> node;
 	};
+
+	struct CopyTransition {
+		StringName from;
+		StringName to;
+		Ref<AnimationNodeStateMachineTransition> transition;
+	};
+
+	List<CopyItem> copy_items_buffer;
+	List<CopyTransition> copy_transitions_buffer;
+
+	void _dup_copy_nodes(List<CopyItem> &r_items, List<CopyTransition> &r_transitions);
+	void _dup_paste_nodes(const List<CopyItem> &r_items, const List<CopyTransition> &p_transitions, const Vector2 &p_position);
+	void _duplicate_nodes();
+	void _copy_nodes(bool p_cut);
+	void _paste_nodes(const Vector2 &p_position);
+	void _clear_copy_buffer();
+	String _deduplicate_node_name(const String &p_base_name);
+	Vector2 _map_to_state_machine(const Vector2 &p_position);
 
 protected:
 	void _notification(int p_what);
@@ -300,7 +322,11 @@ public:
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 	virtual String get_tooltip(const Point2 &p_pos) const override;
 
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
+
 	AnimationNodeStateMachineEditor();
+
+private:
 };
 
 class EditorAnimationMultiTransitionEdit : public RefCounted {

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -41,6 +41,7 @@
 #include "core/os/keyboard.h"
 #include "editor/editor_node.h"
 #include "editor/editor_scale.h"
+#include "editor/editor_settings.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "scene/animation/animation_blend_tree.h"
 #include "scene/animation/animation_player.h"
@@ -51,6 +52,32 @@
 #include "scene/gui/separator.h"
 #include "scene/main/window.h"
 #include "scene/scene_string_names.h"
+
+void AnimationTreeNodeEditorPlugin::_add_standard_context_menu_items(PopupMenu *p_menu, bool p_can_copy, bool p_can_paste) {
+	if (p_can_copy || p_can_paste) {
+		p_menu->add_separator();
+	}
+	if (p_can_copy) {
+		p_menu->add_item(TTR("Cut"), MENU_CUT);
+		p_menu->add_item(TTR("Copy"), MENU_COPY);
+	}
+	if (p_can_paste) {
+		p_menu->add_item(TTR("Paste"), MENU_PASTE);
+	}
+	if (p_can_copy) {
+		p_menu->add_separator();
+		p_menu->add_item(TTR("Delete"), MENU_DELETE);
+		p_menu->add_separator();
+		p_menu->add_item(TTR("Duplicate"), MENU_DUPLICATE);
+	}
+}
+
+AnimationTreeNodeEditorPlugin::AnimationTreeNodeEditorPlugin() {
+	set_process_shortcut_input(true);
+	set_shortcut_context(this);
+
+	set_focus_mode(FOCUS_ALL);
+}
 
 void AnimationTreeEditor::edit(AnimationTree *p_tree) {
 	if (p_tree && !p_tree->is_connected("animation_list_changed", callable_mp(this, &AnimationTreeEditor::_animation_list_changed))) {
@@ -284,6 +311,11 @@ AnimationTreeEditor::AnimationTreeEditor() {
 	add_plugin(memnew(AnimationNodeBlendSpace1DEditor));
 	add_plugin(memnew(AnimationNodeBlendSpace2DEditor));
 	add_plugin(memnew(AnimationNodeStateMachineEditor));
+
+	ED_SHORTCUT("blend_tree_editor/cut", TTR("Cut"), KeyModifierMask::CMD_OR_CTRL | Key::X);
+	ED_SHORTCUT("blend_tree_editor/copy", TTR("Copy"), KeyModifierMask::CMD_OR_CTRL | Key::C);
+	ED_SHORTCUT("blend_tree_editor/paste", TTR("Paste"), KeyModifierMask::CMD_OR_CTRL | Key::V);
+	ED_SHORTCUT("blend_tree_editor/duplicate", TTR("Duplicate"), KeyModifierMask::CMD_OR_CTRL | Key::D);
 }
 
 void AnimationTreeEditorPlugin::edit(Object *p_object) {

--- a/editor/plugins/animation_tree_editor_plugin.h
+++ b/editor/plugins/animation_tree_editor_plugin.h
@@ -42,9 +42,25 @@ class ScrollContainer;
 class AnimationTreeNodeEditorPlugin : public VBoxContainer {
 	GDCLASS(AnimationTreeNodeEditorPlugin, VBoxContainer);
 
+protected:
+	enum {
+		MENU_LOAD_FILE = 1000,
+		MENU_PASTE = 1001,
+		MENU_LOAD_FILE_CONFIRM = 1002,
+		MENU_DUPLICATE = 1003,
+		MENU_CUT = 1004,
+		MENU_COPY = 1005,
+		MENU_DELETE = 1006,
+		MENU_USER_ID
+	};
+
+	void _add_standard_context_menu_items(PopupMenu *p_menu, bool p_can_copy, bool p_can_paste);
+
 public:
 	virtual bool can_edit(const Ref<AnimationNode> &p_node) = 0;
 	virtual void edit(const Ref<AnimationNode> &p_node) = 0;
+
+	AnimationTreeNodeEditorPlugin();
 };
 
 class AnimationTreeEditor : public VBoxContainer {


### PR DESCRIPTION
Adds the above functions to the animation blend tree, state machine and 1D / 2D blend space editors. Also exposes the existing delete function in the context menu and implements duplicate via menu and keyboard shortcut (CTRL+D), and CTRL+Drag for copying animation nodes.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
